### PR TITLE
Language change dropdown

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -1,0 +1,8 @@
+en:
+  code: "en"
+  label: "English"
+  icon: "🇬🇧"
+es:
+  code: "es"
+  label: "Español"
+  icon: "🇪🇸"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -135,6 +135,12 @@ services :
     tags :
       - { name : 'twig.extension' }
 
+  App\EventListener\LocaleListener :
+    arguments :
+      $defaultLocale: 'en'
+    tags :
+      - { name: kernel.event_subscriber }
+
 
   Doctrine\Migrations\DependencyFactory :
     alias : doctrine.migrations.dependency_factory

--- a/src/Controller/Application/LanguageController.php
+++ b/src/Controller/Application/LanguageController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Application;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use App\Service\LanguageService;
+
+#[Route('/language', name: 'language_')]
+class LanguageController extends AbstractController
+{
+    #[Route('/change-language/{code}', name: 'change_language', methods: ['GET'])]
+    public function changeLanguage(string $code, Request $request, LanguageService $languageService): Response
+    {
+        $languages = $languageService->getLanguages();
+
+        if (!(array_key_exists($code, $languages))) {
+            $this->addFlash('error', $this->trans('application.language.language_change_error', [], 'application'));
+
+            return $this->safeRedirect($request, 'app_index');
+        }
+
+        $session = $request->getSession();
+        $session->set('_locale', $code);
+
+        $this->addFlash('success', $this->trans('application.language.language_change_success', [], 'application'));
+
+        return $this->safeRedirect($request, 'app_index');
+    }
+
+    #[Route('/get-languages', name: 'get_languages', methods: ['GET'])]
+    public function getLanguages(LanguageService $languageService): JsonResponse
+    {
+        return new JsonResponse($languageService->getLanguages(), 200);
+    }
+}

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Http\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class LocaleListener implements EventSubscriberInterface
+{
+    private RequestStack $requestStack;
+    private string $defaultLocale;
+
+    public function __construct(RequestStack $requestStack, string $defaultLocale = 'en')
+    {
+        $this->requestStack = $requestStack;
+        $this->defaultLocale = $defaultLocale;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $session = $this->requestStack->getSession();
+
+        $locale = $session->get('_locale', $this->defaultLocale);
+        $request->setLocale($locale);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', 20]],
+        ];
+    }
+}

--- a/src/Service/LanguageService.php
+++ b/src/Service/LanguageService.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class LanguageService
+{
+    private ParameterBagInterface $parameterBag;
+
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        $this->parameterBag = $parameterBag;
+    }
+
+    public function getLanguages(): array
+    {
+        $configFile = $this->parameterBag->get('kernel.project_dir') . '/config/languages.yaml';
+
+        return Yaml::parseFile($configFile);
+    }
+}

--- a/src/Twig/Extensions.php
+++ b/src/Twig/Extensions.php
@@ -65,6 +65,7 @@ class Extensions extends AbstractExtension
             new TwigFilter('parseDateString', [$this, 'parseDateString']),
             new TwigFilter('dateTimeToUserSettings', [$this, 'dateTimeToUserSettings']),
             new TwigFilter('formatScore', [$this, 'formatScore']),
+            new TwigFilter('json_decode', $this->json_decode(...)),
         ];
     }
 
@@ -358,5 +359,16 @@ class Extensions extends AbstractExtension
     public function getLastImprovementStage(AssessmentStream $assessmentStream): ?\App\Entity\Improvement
     {
         return $assessmentStream->getLastImprovementStage();
+    }
+
+    public function json_decode($jsonString): mixed
+    {
+        $decoded = [];
+        try {
+            $decoded = json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+        }
+
+        return $decoded;
     }
 }

--- a/templates/application/partials/nav/_header_navbar_right.html.twig
+++ b/templates/application/partials/nav/_header_navbar_right.html.twig
@@ -11,6 +11,8 @@
     )) }}
 </div>
 
+{% include 'application/partials/nav/language_dropdown.html.twig' %}
+
 <div class="header-btn-lg user-menu-nav justify-content-end w-auto">
     <div class="widget-content p-0">
         <div class="widget-content-wrapper">

--- a/templates/application/partials/nav/language_dropdown.html.twig
+++ b/templates/application/partials/nav/language_dropdown.html.twig
@@ -1,0 +1,36 @@
+<div id="language-dropdown" class="header-btn-lg language-menu-nav justify-content-end w-auto">
+    {% set languages = render(controller('App\\Controller\\Application\\LanguageController::getLanguages'))|json_decode %}
+    <div class="widget-content p-0">
+        <div class="widget-content-wrapper">
+            <div class="widget-content-left ml-3">
+                <div class="btn-group">
+                    <a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="p-0 btn">
+                        <span class="mb-2 mt-2 btn-icon btn btn-outline-info text-nowrap">
+                            <span class="d-inline-block">
+                                {% if languages[app.request.locale] is defined %}
+                                    <span>{{ languages[app.request.locale].icon }} {{ languages[app.request.locale].label }}</span>
+                                {% endif %}
+                                <i class="fa fa-angle-down opacity-8"></i>
+                            </span>
+                        </span>
+                    </a>
+                    <div tabindex="-1" role="menu" aria-hidden="true" class="rm-pointers dropdown-menu-sm dropdown-menu dropdown-menu-right">
+                        <div class="scrollbar-container ps">
+                            <ul class="nav flex-column">
+                                <li class="nav-item">
+                                    {% for language in languages %}
+                                        {% if app.request.locale != language.code  %}
+                                            <a href="{{ path('app_language_change_language', {'code': language.code}) }}" class="nav-link btn dropdown-item">
+                                                <span>{{ language.icon }} {{ language.label }}</span>
+                                            </a>
+                                        {% endif %}
+                                    {% endfor %}
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/functional/LanguageControllerTest.php
+++ b/tests/functional/LanguageControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\functional;
+
+use App\Entity\User;
+use App\Enum\Role;
+use App\Tests\_support\AbstractWebTestCase;
+use App\Tests\builders\UserBuilder;
+use Symfony\Component\HttpFoundation\Request;
+
+class LanguageControllerTest extends AbstractWebTestCase
+{
+    /**
+     * @dataProvider changeLanguageProvider
+     * @testdox $_dataName
+     */
+    public function testChangeLanguage(array $entitiesToPersist, User $user, string $languageCodeToChangeTo, array $expectedText): void
+    {
+        $this->persistEntities(...$entitiesToPersist);
+
+        $this->client->loginUser($user, "boardworks");
+
+        $this->client->request(Request::METHOD_GET, $this->urlGenerator->generate('app_language_change_language', ['code' => $languageCodeToChangeTo]));
+        $this->client->request(Request::METHOD_GET, $this->urlGenerator->generate('app_dashboard_index'));
+
+        self::assertSelectorExists('#language-dropdown');
+
+        $crawler = $this->client->getCrawler();
+
+        $result = [
+            "Dashboard" => $crawler->filter('li.nav-item a[href="/dashboard"] span')->text(),
+            "Assessment" => $crawler->filter('li.nav-item a[href="/model/showPractice"] span')->text(),
+            "Reporting" => $crawler->filter('li.nav-item a[href="/reporting"] span')->text(),
+        ];
+
+        foreach ($result as $key => $value) {
+            self::assertEquals($expectedText[$key], $value);
+        }
+    }
+
+    public function changeLanguageProvider(): \Generator
+    {
+        yield "Test 1 - Test that switching to spanish changes the translations" => [
+            [
+                $user = (new UserBuilder())->build(),
+            ],
+            $user,
+            'es', // language code to change to
+            [
+                "Dashboard" => "Panel de control",
+                "Assessment" => "Evaluación",
+                "Reporting" => "Informes"
+            ], // expected spanish translations
+        ];
+    }
+}

--- a/translations/application+intl-icu.en.yaml
+++ b/translations/application+intl-icu.en.yaml
@@ -655,3 +655,7 @@ application :
     validated_by : "Validated by {name}"
     improved_by : "Improved by {name}"
     auto_validated : "Auto validated"
+
+  language:
+    language_change_success: "The language has been successfully changed"
+    language_change_error: "There was an error while changing the language"

--- a/translations/application+intl-icu.es.yaml
+++ b/translations/application+intl-icu.es.yaml
@@ -361,48 +361,48 @@ application :
         =50 {No aplica}
         other {No especificado}
       }
-  organization_domain : Dominio de la organización
-  organization_role_error : Hubo un error al configurar tu rol en la organización
-  edit_roles : Editar roles
-  details_button : Ver y modificar información del usuario
-  details_title : Detalles del usuario {user}
-  manage_roles_title : Cambiar roles
-  manage_roles_description : Selecciona los roles deseados y haz clic en el botón de guardar
-  projects : Alcances
-  group : Equipo
-  groups : Equipos
-  edit_group : Cambiar equipo
-  edit_projects : Editar alcance
-  manage_projects_title : Alcance asignado
-  manage_projects_description : Asigna un alcance a este usuario. Ten en cuenta que el rol de usuario es global y no puede definirse por alcance.
-  project_edit_success : Los alcances se han guardado correctamente
-  user_edit_success : El usuario se ha guardado correctamente
-  assignments : "Asignaciones"
-  active_assignments : "Asignaciones abiertas"
-  bad_groups : Grupos no válidos proporcionados
-  date_format : Formato de fecha
-  time_zone : Zona horaria
-  date_format_not_selected : No seleccionado
-  time_zone_not_selected : No seleccionado
-  import_title : Importar nuevos usuarios
-  import_title_text : Al crear un usuario, este recibirá inmediatamente un correo electrónico de invitación a SAMMY con sus datos de inicio de sesión.
-  import_button : Importar
-  import_bad_mime_type : Archivo no válido
-  import_file_too_large : El archivo es demasiado grande
-  download_import_template : Descargar plantilla
-  import_zero_sheets : No se proporcionaron hojas
-  import_success : Se importaron un total de «{users}» usuarios
-  import_wrong_roles : Roles incorrectos
-  import_users_button : Importar usuarios desde Excel
-  import_users_part_of_group : Los usuarios importados formarán parte del grupo «{group}»
-  import_users_no_group : Los usuarios importados no tendrán grupo
-  required_property : Propiedad requerida
-  import_too_many_cols : Se proporcionaron demasiadas columnas
-  export_users_button : Exportar usuarios a Excel
-  export_error : Ocurrió un error durante la exportación
-  total_users : Número total de usuarios
-  search_by_placeholder : Buscar por Nombre
-  roles_change_warning : 'Ten en cuenta que si cambias tus roles, deberás volver a autenticarte'
+    organization_domain : Dominio de la organización
+    organization_role_error : Hubo un error al configurar tu rol en la organización
+    edit_roles : Editar roles
+    details_button : Ver y modificar información del usuario
+    details_title : Detalles del usuario {user}
+    manage_roles_title : Cambiar roles
+    manage_roles_description : Selecciona los roles deseados y haz clic en el botón de guardar
+    projects : Alcances
+    group : Equipo
+    groups : Equipos
+    edit_group : Cambiar equipo
+    edit_projects : Editar alcance
+    manage_projects_title : Alcance asignado
+    manage_projects_description : Asigna un alcance a este usuario. Ten en cuenta que el rol de usuario es global y no puede definirse por alcance.
+    project_edit_success : Los alcances se han guardado correctamente
+    user_edit_success : El usuario se ha guardado correctamente
+    assignments : "Asignaciones"
+    active_assignments : "Asignaciones abiertas"
+    bad_groups : Grupos no válidos proporcionados
+    date_format : Formato de fecha
+    time_zone : Zona horaria
+    date_format_not_selected : No seleccionado
+    time_zone_not_selected : No seleccionado
+    import_title : Importar nuevos usuarios
+    import_title_text : Al crear un usuario, este recibirá inmediatamente un correo electrónico de invitación a SAMMY con sus datos de inicio de sesión.
+    import_button : Importar
+    import_bad_mime_type : Archivo no válido
+    import_file_too_large : El archivo es demasiado grande
+    download_import_template : Descargar plantilla
+    import_zero_sheets : No se proporcionaron hojas
+    import_success : Se importaron un total de «{users}» usuarios
+    import_wrong_roles : Roles incorrectos
+    import_users_button : Importar usuarios desde Excel
+    import_users_part_of_group : Los usuarios importados formarán parte del grupo «{group}»
+    import_users_no_group : Los usuarios importados no tendrán grupo
+    required_property : Propiedad requerida
+    import_too_many_cols : Se proporcionaron demasiadas columnas
+    export_users_button : Exportar usuarios a Excel
+    export_error : Ocurrió un error durante la exportación
+    total_users : Número total de usuarios
+    search_by_placeholder : Buscar por Nombre
+    roles_change_warning : 'Ten en cuenta que si cambias tus roles, deberás volver a autenticarte'
 
   session :
     modal_title : Tu sesión ha expirado
@@ -612,7 +612,7 @@ application :
   stream :
     submit : Finalizar la evaluación y enviar para validación
     retract-submission : Retirar envío del flujo
-    restricted_view : Vista restringida: no tienes el rol adecuado para trabajar en este flujo
+    restricted_view : 'Vista restringida: no tienes el rol adecuado para trabajar en este flujo'
     validation_skipped_zero : Se respondieron las tres preguntas con "No", por lo que se omitió el paso de validación.
     validation_skipped_threshold : "Se omitió el paso de validación porque la puntuación no supera el umbral de validación ({threshold}<sup>*</sup>) para este ámbito. <br> * Puedes cambiar este valor en el menú \"Gestionar ámbitos\"."
     evidence_empty : No se ha subido documentación para este flujo.
@@ -655,3 +655,7 @@ application :
     validated_by : "Validado por {name}"
     improved_by : "Mejorado por {name}"
     auto_validated : "Validado automáticamente"
+
+  language:
+    language_change_success: "El idioma ha sido cambiado exitosamente"
+    language_change_error: "Hubo un error al cambiar el idioma"


### PR DESCRIPTION
>Adds a language dropdown which loads languages from `config/languages.yaml`;
>Each added language in `config/languages.yaml` needs to have a translation and messages file in the `translations` directory;
>Added json_decode filter for twigs;
>Added a test which checks if the language was successfully changed;
>Fixed some inlining and translation problems in `application+intl-icu.es.yaml`;
