### PR TITLE
Scopes search fix

### DIFF
--- a/src/Controller/Application/ProjectController.php
+++ b/src/Controller/Application/ProjectController.php
@@ -276,7 +276,7 @@ class ProjectController extends AbstractController
         $user = $this->getUser();
         $page = $request->query->getInt('page', 1);
         $searchTerm = $request->query->get('searchTerm', '');
-        $archived = $request->query->getInt('archived', 0);
+        $archived = (int)$request->query->get('archived', 0);
         $projects = $projectRepository->findOptimized(searchTerm: $searchTerm, page: $page, archived: $archived, returnPaginated: true);
         $projectMkpi = $scoreService->getProjectScores(new \DateTime('now'), true, ...$projects->getResults());
 


### PR DESCRIPTION
>archived query param is now cast to int and uses get with default value of 0 if missing