### PR TITLE
Moved part of chown to Dockerfile. Made composer install be run as www-data

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,9 @@ services:
   app:
     build:
       context: .
+      args :
+        PUID : ${PUID:-1000}
+        PGID : ${PGID:-1000}
     restart: unless-stopped
     environment :
       - DATABASE_URL=mysql://sammy:sammy@db:3306/sammy?serverVersion=11.3.2-MariaDB

--- a/docker-build/start-apache
+++ b/docker-build/start-apache
@@ -2,12 +2,6 @@
 
 shopt -s nocasematch
 
-if [[ -z "$PUID" ]] ; then
-  MY_PUID=1000
-else
-  MY_PUID=${PUID}
-fi
-
 SYMFONY_CONSOLE=/var/www/bin/console
 if [[ -f "$SYMFONY_CONSOLE" ]]; then
   php ${SYMFONY_CONSOLE} cache:clear
@@ -15,10 +9,7 @@ if [[ -f "$SYMFONY_CONSOLE" ]]; then
   php ${SYMFONY_CONSOLE} --no-interaction doctrine:migrations:migrate
 fi
 
-usermod -u ${MY_PUID} www-data \
-  && groupmod -g ${MY_PUID} www-data \
-  && chown -R www-data:www-data /var/www \
-  && chown -R www-data:www-data /var/log/cron
+chown -R www-data:www-data /var/www/var
 
 shopt -u nocasematch
 


### PR DESCRIPTION
Fixes #112 

•	Adjusted the Docker setup by moving part of the chown process into the Dockerfile.
•	Ensured that composer install runs under the www-data user, rather than as root.
•	Changed ownership of /var/www/var to the www-data user.