### PR TITLE
Removed error on empty credential for mail

### DIFF
--- a/src/Command/ProcessMailingCommand.php
+++ b/src/Command/ProcessMailingCommand.php
@@ -32,9 +32,7 @@ class ProcessMailingCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $host = $this->parameterBag->get('phpmailer.smtp.host');
         $port = (int) $this->parameterBag->get('phpmailer.smtp.port');
-        $username = $this->parameterBag->get('phpmailer.smtp.username');
-        $password = $this->parameterBag->get('phpmailer.smtp.password');
-        if ($host === '' || $port === 0 || $username === '' || $password === '') {
+        if ($host === '' || $port === 0) {
             $io->text('[' . date('c') . '] Mail cron - Missing mail configuration');
 
             return Command::SUCCESS;


### PR DESCRIPTION
Allowed to skip username and password in mail sending. Relates to #114