### PR TITLE
Converted mail env vars to bool

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,9 +19,9 @@ parameters :
   phpmailer.smtp.username : '%env(resolve:PHPMAILER_SMTP_USERNAME)%'
   phpmailer.smtp.password : '%env(resolve:PHPMAILER_SMTP_PASSWORD)%'
   phpmailer.smtp.default.sender : '%env(resolve:PHPMAILER_SMTP_DEFAULT_SENDER)%'
-  phpmailer.smtp.use.auth : '%env(resolve:PHPMAILER_SMTP_USE_AUTH)%'
+  phpmailer.smtp.use.auth : '%env(bool:PHPMAILER_SMTP_USE_AUTH)%'
   phpmailer.smtp.default.encryption : '%env(resolve:PHPMAILER_SMTP_DEFAULT_ENCRYPTION)%'
-  phpmailer.smtp.auto.tls : '%env(resolve:PHPMAILER_SMTP_AUTO_TLS)%'
+  phpmailer.smtp.auto.tls : '%env(bool:PHPMAILER_SMTP_AUTO_TLS)%'
 
 services :
   # default configuration for services in *this* file

--- a/src/Service/MailingService.php
+++ b/src/Service/MailingService.php
@@ -193,11 +193,11 @@ class MailingService
             $mail->isSMTP();
             $mail->Host = $this->parameterBag->get('phpmailer.smtp.host');
             $mail->Port = (int) $this->parameterBag->get('phpmailer.smtp.port');
-            $mail->SMTPAuth = (bool) $this->parameterBag->get('phpmailer.smtp.use.auth');;
+            $mail->SMTPAuth = $this->parameterBag->get('phpmailer.smtp.use.auth');;
             $mail->SMTPSecure = $this->parameterBag->get('phpmailer.smtp.default.encryption');
             $mail->Username = $this->parameterBag->get('phpmailer.smtp.username');
             $mail->Password = $this->parameterBag->get('phpmailer.smtp.password');
-            $mail->SMTPAutoTLS = (bool) $this->parameterBag->get('phpmailer.smtp.auto.tls');
+            $mail->SMTPAutoTLS = $this->parameterBag->get('phpmailer.smtp.auto.tls');
 
             if ($from === null) {
                 $from = $this->parameterBag->get('phpmailer.smtp.default.sender');


### PR DESCRIPTION
Use bool processor for PHPMailer SMTP boolean configs

Convert PHPMAILER_SMTP_USE_AUTH and PHPMAILER_SMTP_AUTO_TLS 
environment variables to use bool: processor instead of resolve: 
to ensure proper boolean type casting.