### PR TITLE
Exposed database url in /etc/environment, so the cronjob can see it

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       - REDIS_HOST=redis
     volumes :
       - ./logs:/var/www/var/log
+      - ./logs/cron:/var/log/cron
       - app_data:/var/www/private
     ports :
       - 8000:80

--- a/docker-build/cron
+++ b/docker-build/cron
@@ -5,7 +5,7 @@
 # / / / / ,-- DAY OF WEEK
 #/ / / / /
 HOME=/var/www
-*/2 * * * * root su -s /bin/bash -c '/usr/local/bin/php /var/www/bin/console app:process-mailing >> /var/log/cron/cron.log' www-data
+*/2 * * * * root su -s /bin/bash -c '/usr/local/bin/php /var/www/bin/console app:process-mailing >> /var/log/cron/cron.log 2>&1' www-data
 
 
 #preserve empty line at end!!!

--- a/docker-build/start-apache
+++ b/docker-build/start-apache
@@ -11,6 +11,10 @@ fi
 
 chown -R www-data:www-data /var/www/var
 
+cat > /etc/environment << EOF
+DATABASE_URL=${DATABASE_URL}
+EOF
+
 shopt -u nocasematch
 
 service cron start


### PR DESCRIPTION
Fixes #127 

Export DATABASE_URL in start-apache script to /etc/environment - ensures database credentials are available system-wide for scheduled tasks

Add error logging to cron job with 2>&1 - captures both success messages and error details in cron logs instead of losing error output

Mount cron logs to host filesystem with ./logs/cron:/var/log/cron - allows developers to easily view cron execution logs from the host machine without entering the container