### PR TITLE
Update the Dockerfile for export functionality to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ CMD ["start-apache"]
 
 
 COPY --chown=www-data:www-data . /var/www
+COPY --chown=www-data:www-data . /var/www/private
 COPY --chown=www-data:www-data --from=js-build /build/public/shared/dependency /var/www/public/shared/dependency
 COPY --chown=www-data:www-data --from=js-build /build/public/front/dependency /var/www/public/front/dependency
 WORKDIR /var/www


### PR DESCRIPTION
Updated the Dockerfile by adding the below line:

COPY --chown=www-data:www-data . /var/www/private

This will allow the export functionality to create a folder under /var/www/private.